### PR TITLE
WIP: calling cloud_restore apis in get and restore call

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -909,36 +909,55 @@ void rgw_build_iam_environment(rgw::sal::Driver* driver,
 }
 
 /*
- * GET on CloudTiered objects is processed only when sent from the sync client.
- * In all other cases, fail with `ERR_INVALID_OBJECT_STATE`.
+ * GET on CloudTiered objects either it will synced to other zones.
+ * In all other cases, it will try to fetch the object from remote cloud endpoint.
  */
-int handle_cloudtier_obj(rgw::sal::Attrs& attrs, bool sync_cloudtiered) {
+int handle_cloudtier_obj(req_state* s, const DoutPrefixProvider *dpp, rgw::sal::Driver* driver,
+                         rgw::sal::Attrs& attrs, bool sync_cloudtiered, RGWObjTier tier_config, optional_yield y)
+{
   int op_ret = 0;
-  auto attr_iter = attrs.find(RGW_ATTR_MANIFEST);
-  if (attr_iter != attrs.end()) {
-    RGWObjManifest m;
-    try {
-      decode(m, attr_iter->second);
-      if (m.get_tier_type() == "cloud-s3") {
-        if (!sync_cloudtiered) {
-          /* XXX: Instead send presigned redirect or read-through */
-          op_ret = -ERR_INVALID_OBJECT_STATE;
-        } else { // fetch object for sync and set cloud_tier attrs
-          bufferlist t, t_tier;
-          RGWObjTier tier_config;
-          m.get_tier_config(&tier_config);
-
-          t.append("cloud-s3");
-          attrs[RGW_ATTR_CLOUD_TIER_TYPE] = t;
-          encode(tier_config, t_tier);
-          attrs[RGW_ATTR_CLOUD_TIER_CONFIG] = t_tier;
-        }
-      }
-    } catch (const buffer::end_of_buffer&) {
-      // ignore empty manifest; it's not cloud-tiered
-    } catch (const std::exception& e) {
-    }
+  ldpp_dout(dpp, 20) << "reached handle cloud tier " << dendl;
+  if (sync_cloudtiered) {
+    bufferlist t, t_tier;
+    t.append("cloud-s3");
+    attrs[RGW_ATTR_CLOUD_TIER_TYPE] = t;
+    encode(tier_config, t_tier);
+    attrs[RGW_ATTR_CLOUD_TIER_CONFIG] = t_tier;
+	  return op_ret;
   }
+
+  rgw::sal::Bucket* pbucket = NULL;
+  pbucket = s->bucket.get();
+  std::unique_ptr<rgw::sal::PlacementTier> tier;
+  rgw_placement_rule target_placement;
+
+  target_placement.inherit_from(pbucket->get_placement_rule());
+  auto attr_iter = attrs.find(RGW_ATTR_STORAGE_CLASS);
+  if (attr_iter != attrs.end()) {
+      target_placement.storage_class = attr_iter->second.to_str();
+  }
+  op_ret = driver->get_zone()->get_zonegroup().get_placement_tier(target_placement, &tier);
+  ldpp_dout(dpp, 20) << "getting tier placement handle cloud tier" << op_ret <<
+                     " storage class " << target_placement.storage_class << dendl;
+  if (op_ret < 0) {
+   return op_ret;
+  }
+  rgw_bucket_dir_entry ent;
+  ent.key.name = s->object->get_key().name;
+  ent.meta.accounted_size = ent.meta.size = s->obj_size;
+  ent.meta.etag = "" ;
+  ceph::real_time mtime = s->object->get_mtime();
+  uint64_t epoch = 0;
+  op_ret = get_system_versioning_params(s, &epoch, NULL);
+  ldpp_dout(dpp, 20) << "getting versioning params tier placement handle cloud tier" << op_ret << dendl;
+  // TODO : pass proper values for etag, days and fill up necessary fields in ent
+  op_ret = s->object->restore_obj_from_cloud(pbucket, tier.get(), target_placement, ent, s->cct,
+                                                mtime, epoch, 1, dpp, y, s->bucket->get_info().flags);
+	if (op_ret < 0) {
+    ldpp_dout(dpp, 0) << "object fetching failed" << op_ret << dendl;
+	  return op_ret;
+	}
+  ldpp_dout(dpp, 20) << "object fetching succeed" << dendl;
 
   return op_ret;
 }
@@ -2331,15 +2350,27 @@ void RGWGetObj::execute(optional_yield y)
     } catch (const buffer::error&) {}
   }
 
-  if (get_type() == RGW_OP_GET_OBJ && get_data) {
-    op_ret = handle_cloudtier_obj(attrs, sync_cloudtiered);
-    if (op_ret < 0) {
-      ldpp_dout(this, 4) << "Cannot get cloud tiered object: " << *s->object
+  attr_iter = attrs.find(RGW_ATTR_MANIFEST);
+  if (attr_iter != attrs.end()) {
+    RGWObjManifest m;
+    try {
+    decode(m, attr_iter->second);
+    if (get_type() == RGW_OP_GET_OBJ && get_data && m.get_tier_type() == "cloud-s3") {
+      RGWObjTier tier_config;
+      m.get_tier_config(&tier_config);
+      op_ret = handle_cloudtier_obj(s, this, driver, attrs, sync_cloudtiered, tier_config, y);
+      if (op_ret < 0) {
+        ldpp_dout(this, 4) << "Cannot get cloud tiered object: " << *s->object
           <<". Failing with " << op_ret << dendl;
-      if (op_ret == -ERR_INVALID_OBJECT_STATE) {
-        s->err.message = "This object was transitioned to cloud-s3";
+          if (op_ret == -ERR_INVALID_OBJECT_STATE) {
+            s->err.message = "This object was transitioned to cloud-s3";
+          }
+          goto done_err;
+        }
       }
-      goto done_err;
+    } catch (const buffer::end_of_buffer&) {
+      // ignore empty manifest; it's not cloud-tiered
+    } catch (const std::exception& e) {
     }
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5077,7 +5077,37 @@ void RGWRestoreObj::execute(optional_yield y)
     op_ret = -ERR_NO_SUCH_BUCKET;
     return;
   }
-  
+  s->object->set_atomic();
+  int op_ret = s->object->get_obj_attrs(y, this);
+  if (op_ret < 0) {
+    ldpp_dout(this, 1) << "failed to fetch get_obj_attrs op ret = " << op_ret << dendl;
+    return;
+  }
+  rgw::sal::Attrs attrs = s->object->get_attrs();
+  auto attr_iter = attrs.find(RGW_ATTR_MANIFEST);
+  if (attr_iter != attrs.end()) {
+    RGWObjManifest m;
+    decode(m, attr_iter->second);
+    RGWObjTier tier_config;
+    m.get_tier_config(&tier_config);
+    if (m.get_tier_type() == "cloud-s3") {
+      op_ret = handle_cloudtier_obj(s, this, driver, attrs, false, tier_config, y);
+      if (op_ret < 0) {
+        ldpp_dout(this, 4) << "Cannot get cloud tiered object: " << *s->object
+        <<". Failing with " << op_ret << dendl;
+        if (op_ret == -ERR_INVALID_OBJECT_STATE) {
+          s->err.message = "This object was transitioned to cloud-s3";
+        }
+      }
+    } else {
+      ldpp_dout(this, 20) << "not cloud tier object erroring" << dendl;
+      op_ret = -ERR_INVALID_OBJECT_STATE;
+    }
+  } else {
+    ldpp_dout(this, 20) << " manifest not found" << dendl;
+  }
+  ldpp_dout(this, 20) << "completed restore" << dendl;
+
   return;
 }
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]
rgw/cloudtier : calling cloud restore apis in get and restore call

This PR handles following :

GET request 

- It allows read through for cloud tiered objects via `restore_obj_from_cloud`

RESTORE request

- It checks whether object is cloud tiered, returns error if not otherwise fetch object via   `restore_obj_from_cloud`

TODO: 

- add option to allow cloud_restore option similar to retain_head_object
- Implementation of callbacks
- Even read through works, for the first request user gets empty object
- Make sure all the values are passed correctly to `restore_obj_from_cloud`
- Parsed parameters like o/p location, days in restore call pass to down to `restore_obj_from_cloud`
- Include cli option for restore days incase of get request
- Handling restore status

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: Jiffin Tony Thottan<thottanjiffin@gmail.com>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

rgw/cloudtier : calling cloud restore apis in get and restore call

This PR handles the following :

GET request 

- It allows read-through for cloud-tiered objects via `restore_obj_from_cloud`

RESTORE request

- It checks whether object is cloud tiered, returns error if not otherwise fetch object via   `restore_obj_from_cloud`

## TODO: 

- add option to allow cloud_restore option similar to retain_head_object
- Implementation of callbacks
- Even read through works, for the first request user gets empty object
- Make sure all the values are passed correctly to `restore_obj_from_cloud`
- Parsed parameters like o/p location, days in restore call pass to down to `restore_obj_from_cloud`
- Include cli option for restore days incase of get request
- Handling restore status

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
