### PR TITLE
Fixing ObjCategory and duplicate storage-class

### DIFF
--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -42,9 +42,8 @@ void read_cloudtier_info_from_attrs(rgw::sal::Attrs& attrs, RGWObjCategory& cate
     string m = i.to_str();
 
     if (m == "cloud-s3") {
+      category = RGWObjCategory::CloudTiered;
       manifest.set_tier_type("cloud-s3");
-
-      {
       auto config_iter = attrs.find(RGW_ATTR_CLOUD_TIER_CONFIG);
       if (config_iter != attrs.end()) {
         auto i = config_iter->second.cbegin();
@@ -58,46 +57,10 @@ void read_cloudtier_info_from_attrs(rgw::sal::Attrs& attrs, RGWObjCategory& cate
         } catch (buffer::error& err) {
         }
       }
-      }
     }
     attrs.erase(attr_iter);
   }
 
-  // retain the object category as CloudTiered for Cloud-transitioned or 
-  // temporary restored or RestoreInProgress objects.
-  auto r_iter = attrs.find(RGW_ATTR_RESTORE_STATUS);
-  if (r_iter != attrs.end()) {
-    rgw::sal::RGWRestoreStatus st = rgw::sal::RGWRestoreStatus::None;
-    auto iter = r_iter->second.cbegin();
-
-    try {
-      using ceph::decode;
-      decode(st, iter);
-
-      if (st != rgw::sal::RGWRestoreStatus::CloudRestored) {
-        category = RGWObjCategory::CloudTiered;
-      } else {
-        auto config_iter = attrs.find(RGW_ATTR_RESTORE_TYPE);
-        if (config_iter != attrs.end()) {
-          rgw::sal::RGWRestoreType rt = rgw::sal::RGWRestoreType::None;
-          iter = config_iter->second.cbegin();
-
-          try {
-             using ceph::decode;
-             decode(rt, iter);
-
-             if (rt == rgw::sal::RGWRestoreType::Permanent) {
-               category = RGWObjCategory::Main;
-             } else {
-               category = RGWObjCategory::CloudTiered;
-             }
-           } catch (buffer::error& err) {
-           }
-         }
-       }
-     } catch (buffer::error& err) {
-    }
-  }
 }
 
 int HeadObjectProcessor::process(bufferlist&& data, uint64_t logical_offset)

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5278,6 +5278,15 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
     //set same old mtime as that of transition time
     set_mtime = mtime;
 
+    // set tier-config only for temp restored objects, as
+    // permanent copies will be treated as regular objects
+    {
+      t.append("cloud-s3");
+      encode(tier_config, t_tier);
+      attrs[RGW_ATTR_CLOUD_TIER_TYPE] = t;
+      attrs[RGW_ATTR_CLOUD_TIER_CONFIG] = t_tier;
+    }
+
   } else { // permanent restore
     {
       bufferlist bl;
@@ -5296,13 +5305,6 @@ int RGWRados::restore_obj_from_cloud(RGWLCCloudTierCtx& tier_ctx,
     bufferlist bl;
     bl.append(sc.c_str(), sc.size());
     attrs[RGW_ATTR_STORAGE_CLASS] = std::move(bl);
-  }
-
-  {
-    t.append("cloud-s3");
-    encode(tier_config, t_tier);
-    attrs[RGW_ATTR_CLOUD_TIER_TYPE] = t;
-    attrs[RGW_ATTR_CLOUD_TIER_CONFIG] = t_tier;
   }
 
   // XXX: handle COMPLETE_RETRY like in fetch_remote_obj

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -532,7 +532,6 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
 
         if (c_iter != attrs.end()) {
           attrs[RGW_ATTR_STORAGE_CLASS] = c_iter->second;
-          dump_header(s, "x-amz-storage-class", rgw_bl_str(c_iter->second) );
         }
       }
     }


### PR DESCRIPTION
ObjCategory should be set to CloudTiered only for cloud-transitioned objects and temporarily restored objects. Permanent copies are to be treated as regular objects.
Also fixed an issue with setting duplicate `x-amx-storage-class` in the GetObject response


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
